### PR TITLE
update Kivy docs URL. 

### DIFF
--- a/issues.json
+++ b/issues.json
@@ -113,7 +113,7 @@
             "authorUrl": "http://kivy.org/",
             "level": "Intermediate",
             "info": "Discover Kivy the multitouch Python framework for desktop and mobile, and learn how to create a simple game.",
-            "url": "http://kivy.org/docs/pdf/Kivy-latest.pdf",
+            "url": "https://readthedocs.org/projects/kivy/downloads/",
             "cover": "img/cover_kivy.png"
         },
         {


### PR DESCRIPTION
Solution for Issue #51 . I used the downloads page instead for more ebook format options